### PR TITLE
reconcile readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sources, install it in editable mode from a git clone:
 
     git clone https://github.com/cmla/s2p.git --recursive
     cd s2p
-    pip install -e ".[test]"
+    pip install -e .
 
 The `--recursive` option for `git clone` allows to clone all git submodules, such
 as the [iio](https://github.com/mnhrdt/iio) library.


### PR DESCRIPTION
While running through the readme instructions, this command:
`pip install -r ".[test]"`
produces this error:
`ERROR: Could not open requirements file: [Errno 2] No such file or directory: '.[test]'`

This pull request updates the readme to match what the Dockerfile prescribes:
` pip install -e .`