### PR TITLE
msm2: Fix compile error with clang

### DIFF
--- a/3rdparty/msmw2/libstereo_newversion/cc_postprocess.cc
+++ b/3rdparty/msmw2/libstereo_newversion/cc_postprocess.cc
@@ -276,7 +276,7 @@ int cc_postprocess(int w, int h, float *img, float *msk, float *out, float *outm
       if(maxerr< MAXERR && vmax-vmin< MAXDIFF ) {
          for(int i = 0;i<pixels.size();i++) {
             int idx = pixels[i].x + pixels[i].y*w;
-            float vv[3] = {pixels[i].x, pixels[i].y, 0};
+            float vv[3] = {float(pixels[i].x), float(pixels[i].y), float(0.0)};
             out[idx] = eval_model(3, vv, model);
             outmsk[idx] = 254;
          }


### PR DESCRIPTION
Clang version 12.0.1 on Mac throws an error with initializing an array of float from non-floats. This fix casts to float before assigning to that array. 