### PR TITLE
Avoid error in plys_to_dsm when there are no points in cloud.ply

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -443,6 +443,9 @@ def plys_to_dsm(tile):
     # compute the point cloud x, y bounds
     points, _ = ply.read_3d_point_cloud_from_ply(os.path.join(tile['dir'],
                                                               'cloud.ply'))
+    if len(points) == 0:
+        return
+
     xmin, ymin, *_ = np.min(points, axis=0)
     xmax, ymax, *_ = np.max(points, axis=0)
 


### PR DESCRIPTION
Running s2p I ran into an error when only a few pixels in a specific tile have data (due to the ROI shape), resulting in a `cloud.ply` file with zero points for this tile. This gives the following error:

```
computing DSM by tile...
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/s2p_dev/s2p/s2p/parallel.py", line 43, in tilewise_wrapper
    out = fun(*args)
  File "/s2p_dev/s2p/s2p/__init__.py", line 446, in plys_to_dsm
    xmin, ymin, *_ = np.min(points, axis=0)
  File "<__array_function__ internals>", line 180, in amin
  File "/usr/local/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 2916, in amin
    return _wrapreduction(a, np.minimum, 'min', axis, None, out,
  File "/usr/local/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 86, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
ValueError: zero-size array to reduction operation minimum which has no identity
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/s2p", line 33, in <module>
    sys.exit(load_entry_point('s2p', 'console_scripts', 's2p')())
  File "/s2p_dev/s2p/s2p/cli.py", line 22, in main
    s2p.main(user_cfg)
  File "/s2p_dev/s2p/s2p/__init__.py", line 606, in main
    parallel.launch_calls(plys_to_dsm, tiles, nb_workers, timeout=timeout)
  File "/s2p_dev/s2p/s2p/parallel.py", line 102, in launch_calls
    outputs.append(r.get(timeout))
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
ValueError: zero-size array to reduction operation minimum which has no identity
```

This can be fixed easily by checking if there are points in the `cloud.ply` file before trying to create a DSM. 