### PR TITLE
Avoid computing masked tiles

### DIFF
--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -308,6 +308,8 @@ def is_this_tile_useful(x, y, w, h, images_sizes):
     wat_msk = cfg['images'][0]['wat']
     mask = masking.image_tile_mask(x, y, w, h, roi_msk, cld_msk, wat_msk,
                                    images_sizes[0], cfg['border_margin'])
+    if not mask.any():
+        return False, None
     return True, mask
 
 

--- a/s2p/masking.py
+++ b/s2p/masking.py
@@ -69,6 +69,8 @@ def image_tile_mask(x, y, w, h, roi_gml=None, cld_gml=None, raster_mask=None,
         with rasterio.open(raster_mask, 'r') as f:
             mask = np.logical_and(mask, f.read(window=((y, y+h), (x, x+w)),
                                                boundless=True).squeeze())
+        if not mask.any():
+            return mask
 
     # image borders mask
     if img_shape is not None:


### PR DESCRIPTION
When there are a lot of masked tiles you can save a lot of computing time by making sure that s2p doesn't try to generate a DSM for fully masked tiles. So if all values in the `mask` are False, `is_this_tile_useful` should return `False, None`.

I also added two lines to `masking.py` to avoid computing the border mask if all values in the raster mask are False already.

Results of my small test:

*Before this change*
```
Total elapsed time: 0:08:25.749199
```

*After this change*
```
Total elapsed time: 0:05:13.624001
```
