### PR TITLE
Feature: Add --start_from option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The `s2p` CLI usage instructions can be printed with the `-h` and `--help` switc
                             output files and the algorithm parameters
 
     optional arguments:
+      --start_from          Restart from a given step in case of an interruption or to try different parameters.
       -h, --help            show this help message and exit
 
 To run the whole pipeline, call `s2p` with a json configuration file as unique argument:

--- a/s2p/cli.py
+++ b/s2p/cli.py
@@ -15,11 +15,14 @@ def main():
                         help=('path to a json file containing the paths to '
                               'input and output files and the algorithm '
                               'parameters'))
+    parser.add_argument('--start_from', dest='start_from', type=int,
+                        default=0, help="Restart the process from a given step in "
+                                        "case of an interruption or to try different parameters.")
     args = parser.parse_args()
 
     user_cfg = s2p.read_config_file(args.config)
 
-    s2p.main(user_cfg)
+    s2p.main(user_cfg, start_from=args.start_from)
 
     # Backup input file for sanity check
     if not args.config.startswith(os.path.abspath(s2p.cfg['out_dir']+os.sep)):


### PR DESCRIPTION
When running s2p it can be convenient to be able to restart the pipeline from a specific step, either to try some different parameters while not having to rerun the entire pipeline or to continue processing after an interruption or error.

I added numbering to the steps so that it is easy to understand what step to use as an input.