### PR TITLE
Feature: Add geoid height output as a parameter in the config

### DIFF
--- a/s2p/config.py
+++ b/s2p/config.py
@@ -173,3 +173,6 @@ cfg['cargarse_basura'] = True
 # "+proj=utm +zone=40 +south +datum=WGS84 +units=m +vunits=m +no_defs +type=crs" (proj4 string)
 # If None, the local UTM zone will be used
 cfg['out_crs'] = None
+
+# Whether to use EGM96 geoid vertical datum for the out_crs (this parameter is only used if out_crs is None)
+cfg['out_geoid'] = False

--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -136,6 +136,8 @@ def build_cfg(user_cfg):
         utm_zone = rpc_utils.utm_zone(cfg['images'][0]['rpcm'], x, y, w, h)
         epsg_code = geographiclib.epsg_code_from_utm_zone(utm_zone)
         cfg['out_crs'] = "epsg:{}".format(epsg_code)
+        if cfg['out_geoid']:
+            cfg['out_crs'] += "+5773"
     geographiclib.pyproj_crs(cfg['out_crs'])
 
     # get image ground sampling distance


### PR DESCRIPTION
I propose to add a parameter in the config that indicates whether the EGM96 geoid will be used to generate the output DSM when the `out_crs` is not set. 

This makes it more clear that by default the WSG84 vertical datum is used when the `out_crs` is not set and makes it more convenient to use the vertical datum that you want, without having to manually input the UTM zone of a specific image.

ps. this is my last PR for now, I just didn't want to make one big PR with all the changes I implemented locally so I split it into 4 PRs