### PR TITLE
Update pyproj to >3.0.0 and reformat setup.py with PEP-8 guide.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import subprocess
 from codecs import open
-from setuptools import setup, find_packages
-from setuptools.command import develop, build_py
+
+from setuptools import find_packages, setup
+from setuptools.command import build_py, develop
 
 
 def readme():
@@ -13,6 +14,7 @@ class CustomDevelop(develop.develop, object):
     """
     Class needed for "pip install -e ."
     """
+
     def run(self):
         subprocess.check_call("make", shell=True)
         super(CustomDevelop, self).run()
@@ -22,6 +24,7 @@ class CustomBuildPy(build_py.build_py, object):
     """
     Class needed for "pip install s2p"
     """
+
     def run(self):
         super(CustomBuildPy, self).run()
         subprocess.check_call("make", shell=True)
@@ -30,10 +33,12 @@ class CustomBuildPy(build_py.build_py, object):
 
 try:
     from wheel.bdist_wheel import bdist_wheel
+
     class BdistWheel(bdist_wheel):
         """
         Class needed to build platform dependent binary wheels
         """
+
         def finalize_options(self):
             bdist_wheel.finalize_options(self)
             self.root_is_pure = False
@@ -42,37 +47,43 @@ except ImportError:
     BdistWheel = None
 
 
-requirements = ['numpy',
-                'scipy',
-                'rasterio[s3]>=1.2a1',
-                'utm',
-                'pyproj>=2.0.2,<3.0.0',
-                'beautifulsoup4[lxml]',
-                'plyfile',
-                'plyflatten>=0.2.0',
-                'ransac',
-                'rpcm>=1.4.6',
-                'srtm4>=1.1.2',
-                'requests']
+requirements = [
+    "numpy",
+    "scipy",
+    "rasterio[s3]>=1.2a1",
+    "utm",
+    "pyproj>3.0.0",
+    "beautifulsoup4[lxml]",
+    "plyfile",
+    "plyflatten>=0.2.0",
+    "ransac",
+    "rpcm>=1.4.6",
+    "srtm4>=1.1.2",
+    "requests",
+]
 
 extras_require = {
     "test": ["pytest", "pytest-cov", "psutil"],
 }
 
-setup(name="s2p",
-      version="1.0b26dev",
-      description="Satellite Stereo Pipeline.",
-      long_description=readme(),
-      long_description_content_type='text/markdown',
-      url='https://github.com/cmla/s2p',
-      packages=['s2p'],
-      install_requires=requirements,
-      extras_require=extras_require,
-      cmdclass={'develop': CustomDevelop,
-                'build_py': CustomBuildPy,
-                'bdist_wheel': BdistWheel},
-      python_requires=">=3",
-      entry_points="""
+setup(
+    name="s2p",
+    version="1.0b26dev",
+    description="Satellite Stereo Pipeline.",
+    long_description=readme(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/cmla/s2p",
+    packages=["s2p"],
+    install_requires=requirements,
+    extras_require=extras_require,
+    cmdclass={
+        "develop": CustomDevelop,
+        "build_py": CustomBuildPy,
+        "bdist_wheel": BdistWheel,
+    },
+    python_requires=">=3",
+    entry_points="""
           [console_scripts]
           s2p=s2p.cli:main
-      """)
+      """,
+)


### PR DESCRIPTION
# Description

This PR is about solving this [issue](https://github.com/centreborelli/s2p/issues/124), ie, updating `pyproj>3.0.0`. 


## Type of change

The changes of this PR are:

- [x]  Update `pyproj>3.0.0` in `setup.py`.
```
requirements = [
    "numpy",
    "scipy",
    "rasterio[s3]>=1.2a1",
    "utm",
    "pyproj>3.0.0",
    "beautifulsoup4[lxml]",
    "plyfile",
    "plyflatten>=0.2.0",
    "ransac",
    "rpcm>=1.4.6",
    "srtm4>=1.1.2",
    "requests",
]
```
- [x]  Reformat `setup.py` following PEP-8 guide.


# How Has This Been Tested?

This project has been tested with the command, `pytest tests/`, and only 1 test fails.
```
======================================= 1 failed, 32 passed, 4 warnings in 148.84s (0:02:28) ========================================
```

The `tests/end2end_test.py` failed and the error is not coming from s2p but from the `srtm4` package. In `s2p`, it downloads SRTM data from https://srtm.csi.cgiar.org/, but the SSL certificated has been expired (check https://github.com/centreborelli/srtm4/issues/16). Thus the failing test occurs.  
The error:
```
E               requests.exceptions.SSLError: HTTPSConnectionPool(host='srtm.csi.cgiar.org', port=443): Max retries exceeded with url: /wp-content/uploads/files/srtm_5x5/TIFF/srtm_48_17.zip (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1131)')))
```

The error is not from either s2p or srtm4 package but from the website.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [] Existing unit tests pass locally with my changes
