### PR TITLE
Upgrade rpcm to 1.4.8 to support Pleiades Neo [don't merge yet]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Tests Status](https://github.com/centreborelli/s2p/actions/workflows/tests.yml/badge.svg)
 [![PyPI version](https://img.shields.io/pypi/v/s2p)](https://pypi.org/project/s2p)
 
-S2P is a Python library and command line tool that implements a stereo
+S2P is a Python library and command line tool that implements a stereo 
 pipeline which produces elevation models from images taken by high resolution
 optical satellites such as Pléiades, WorldView, QuickBird, Spot or Ikonos. It
 generates 3D point clouds and digital surface models from stereo pairs (two

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ except ImportError:
     BdistWheel = None
 
 
-requirements = ['numpy',
+requirements = ['numpy==1.22.2',
                 'scipy',
                 'rasterio[s3]>=1.2a1',
                 'utm',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ requirements = ['numpy',
                 'plyfile',
                 'plyflatten>=0.2.0',
                 'ransac',
-                'rpcm>=1.4.6',
+                'rpcm>=1.4.8',
                 'srtm4>=1.1.2',
                 'requests']
 


### PR DESCRIPTION
A few months ago I created a [PR in the rpcm repo](https://github.com/centreborelli/rpcm/pull/16) to enable using Pleiades Neo imagery, but this change hasn't been implemented in s2p yet.

~~Before merging this, please merge this PR: https://github.com/centreborelli/rpcm/pull/18 
And create a new release of the rpcm library (also a new `pypi` release)~~
