### PR TITLE
Check if a given window is full of nodata or 0.

### DIFF
--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -282,6 +282,35 @@ def rectangles_intersect(r, s):
     return True
 
 
+def is_tile_all_nodata(path:str, window:rasterio.windows.Window):
+    """Check if pixels in a given window are all nodata.
+
+    Parameters
+    ----------
+    path
+        Path to the raster.
+    window
+        A rasterio.windows.Window object.
+
+    Returns
+    -------
+        Return True if all pixels in the window are nodata.
+        Return False if at least one pixel is non-nodata.
+    """
+    with rasterio.open(path, "r") as ds:
+        arr = ds.read(window=window)
+
+        # NOTE: Many satellite imagery providers use ds.nodata as the value of
+        # nodata pixels. Pleiades and PNeo imagery use None as nodata in their
+        # profile while putting 0 to nodata pixel in reality. Thus, we have to
+        # check both ds.nodata and 0 here. I.e., if a window is full of nodata
+        # or 0, then this window is discarded.
+        if np.all(arr == 0) or np.all(arr == ds.nodata):
+            return True
+        else:
+            return False
+
+
 def is_this_tile_useful(x, y, w, h, images_sizes):
     """
     Check if a tile contains valid pixels.
@@ -297,6 +326,9 @@ def is_this_tile_useful(x, y, w, h, images_sizes):
         useful (bool): bool telling if the tile has to be processed
         mask (np.array): tile validity mask. Set to None if the tile is discarded
     """
+    if is_tile_all_nodata(cfg["images"][0]["img"], rasterio.windows.Window(x, y, w, h)):
+        return False, None
+        
     # check if the tile is partly contained in at least one other image
     rpc = cfg['images'][0]['rpcm']
     for img, size in zip(cfg['images'][1:], images_sizes[1:]):


### PR DESCRIPTION
Dear the team of s2p:
I would like to propose that discarding a tile full of nodata or 0 during the step of `is_this_tile_useful` in `s2p/initialization.py`. It's common that stereo imagery has valid data in the certain AOI and put the unconcerned area as nodata.  
E.g., the following two scenes both have nodata pixels over some parts of area. And the current s2p will create tiles across the whole raster, including the area fill with nodata/0.
<img src="https://user-images.githubusercontent.com/5163329/220100429-3985d738-2091-475f-acdd-f5c33c783115.JPG" width="300">
![PREVIEW_PNEO4_202208140001556_PAN_SEN_PWOI_000028300_1_15_F_1](https://user-images.githubusercontent.com/5163329/220100474-609757a9-4638-4b71-b992-0c7bf291c185.JPG)

### This PR provides two improvements:  
- Speed up the processing time: the discarded tiles will not go through the stereo process (SIFT keypoints finding and matching, rectification, dense matching, triangulation, rasterization), which saves the computation time.
- The output DSM looks nicer and is better for later processes. Here are the DSM comparison between the DSM created before and in this MR.
#### Scene1:
- Before this MR:
<img src="https://user-images.githubusercontent.com/5163329/220102915-f3f27fad-dd9e-43d3-b7c9-33804dcfa01a.png" width="300">
- In this MR:
<img src="https://user-images.githubusercontent.com/5163329/220103107-c9edea7d-869d-496f-9933-efcbd53cd38b.png" width="300">

#### Scene2:
- Before this MR:  
<img src="https://user-images.githubusercontent.com/5163329/220103367-c8fadae6-4b8b-476d-af9d-e4054178646d.png" width="300">
- In this MR:  
<img src="https://user-images.githubusercontent.com/5163329/220103509-03d96bed-2540-4517-a297-055f93f5b7fe.png" width="300">

Please review it and any feedback is appreciated. Thank you.
